### PR TITLE
removed serial port and type from call to SnapConnectFuturesAuto

### DIFF
--- a/EchoTestFutures.py
+++ b/EchoTestFutures.py
@@ -27,7 +27,6 @@ SERIAL_TYPE = snap.SERIAL_TYPE_RS232
 # An example for a typical interface device is shown below
 SERIAL_PORT = 0  # COM1
 # SERIAL_PORT = '/dev/ttyUSB0'
-BRIDGE_NODE = "627d43" # <- Replace this with the address of your bridge node
 
 NUMBER_OF_QUERIES = 100  # More polls == longer test
 TIMEOUT = 1.0  # (in seconds) You might need to increase this if:

--- a/EchoTestFutures.py
+++ b/EchoTestFutures.py
@@ -58,7 +58,8 @@ def run_echo_test(port_type=SERIAL_TYPE, port_no=SERIAL_PORT,
     :param scf: snapconnect-future you want to use
     """
 
-    scf = yield SnapConnectFuturesAuto(port_id=SERIAL_PORT, port_type=SERIAL_TYPE)
+    scf = SnapConnectFuturesAuto()
+    bridge_node = yield scf.open_serial(port_type, port_no)
     # set up to start sending queries to our bridge node
     replies = 0
     # start the clock!
@@ -66,7 +67,7 @@ def run_echo_test(port_type=SERIAL_TYPE, port_no=SERIAL_PORT,
     # start sending queries
     for queries in range(num_queries):
         # we'll use the built in 'str' func to call back
-        result = yield scf.callback_rpc(BRIDGE_NODE, 'str', args=(payload,), retries=3, timeout=timeout)
+        result = yield scf.callback_rpc(bridge_node, 'str', args=(payload,), retries=3, timeout=timeout)
         if result != (PAYLOAD,):
             log.error("we did not receive the correct response %r" % result)
         else:

--- a/README.md
+++ b/README.md
@@ -59,20 +59,10 @@ pip install -r requirements.txt
 
 All configuration for this example is done by changing hardcoded values near the top
 of the `EchoTestFutures.py`, for example:
- 
-#### What is the address of the SNAP Node you want to test against?
 
-This could be your bridge node if you only want to see the effects of the
-serial interface, or it could be a *remote* SNAP node if you also want to
-include the effects of Over-The-Air (OTA) radio communications too.
+#### What serial interface do you want to use to reach your bridge node?
 
-```python
-BRIDGE_NODE = "627d43" # <- Replace this with the address of your bridge node
-```
-
-#### What serial interface do you want to use to reach it?
-
-Or in the remote node case, what serial interface to reach the bridge?
+You will need to modify `SERIAL_TYPE` and `SERIAL_PORT` based on what type of bridge node you have:
 
 ```python
 # You should set these to match YOUR available hardware

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 --extra-index-url https://update.synapse-wireless.com/pypi
-snapconnect-futures>=4.0.1a1,<5.0.0
+snapconnect-futures>=4.0.1a2,<5.0.0


### PR DESCRIPTION
@tylercrumpton 
SnapConnectFuturesAuto no longer opens serial port due to issues
with yielding to a future and unit testing
